### PR TITLE
monkey patch a numpy distutils method to ensure cython building with numpy > 1.10

### DIFF
--- a/nireg/np_distutils_monkey.py
+++ b/nireg/np_distutils_monkey.py
@@ -1,0 +1,40 @@
+# Standard library imports
+from os.path import join as pjoin, dirname
+from distutils.dep_util import newer_group
+from distutils.errors import DistutilsError
+
+from numpy.distutils.misc_util import appendpath
+from numpy.distutils import log
+
+
+def generate_a_pyrex_source(self, base, ext_name, source, extension):
+    ''' Monkey patch for numpy build_src.build_src method
+
+    Uses Cython instead of Pyrex.
+
+    Assumes Cython is present
+    '''
+    if self.inplace:
+        target_dir = dirname(base)
+    else:
+        target_dir = appendpath(self.build_src, dirname(base))
+    target_file = pjoin(target_dir, ext_name + '.c')
+    depends = [source] + extension.depends
+    if self.force or newer_group(depends, target_file, 'newer'):
+        import Cython.Compiler.Main
+        log.info("cythonc:> %s" % (target_file))
+        self.mkpath(target_dir)
+        options = Cython.Compiler.Main.CompilationOptions(
+            defaults=Cython.Compiler.Main.default_options,
+            include_path=extension.include_dirs,
+            output_file=target_file)
+        cython_result = Cython.Compiler.Main.compile(source,
+                                                   options=options)
+        if cython_result.num_errors != 0:
+            raise DistutilsError("%d errors while compiling %r with Cython" \
+                  % (cython_result.num_errors, source))
+    return target_file
+
+
+from numpy.distutils.command import build_src
+build_src.build_src.generate_a_pyrex_source = generate_a_pyrex_source

--- a/nireg/setup.py
+++ b/nireg/setup.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 import os
 
+import np_distutils_monkey # ensure cythonization with numpy version > 1.10
 
 def configuration(parent_package='', top_path=None):
 


### PR DESCRIPTION
Hi, 
In the numpy/distutils/command/build_src.py module,
the method generate_a_pyrex_source does not support Pyrex anymore (since numpy 1.10)
To compile Cython code we have to monkey-patch this method in the setup.
Thanks @matthew-brett for writing this patch !

Cheers,

Gael
